### PR TITLE
fix : 문서화시 필요한 폴더를 생성하도록 기존 생략 코드를 수정, gradlew 버전 변경 8.1.1

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build with Gradle
         run: |
           chmod +x ./gradlew
-          ./gradlew clean build -x test
+          ./gradlew clean build 
 
       - name: Copy files over ssh
         uses: appleboy/scp-action@master

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,4 +47,3 @@ jobs:
       - name: Build and test with Gradle
         run: |
           ./gradlew build
-          ./gradlew test

--- a/docs/index.html
+++ b/docs/index.html
@@ -814,7 +814,7 @@ Host: localhost:8080
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Set-Cookie: jwt-token=dummy-token; Path=/; Max-Age=3600; Expires=Sun, 11 Jun 2023 08:54:29 GMT
+Set-Cookie: jwt-token=dummy-token; Path=/; Max-Age=3600; Expires=Sun, 11 Jun 2023 09:51:35 GMT
 Content-Type: application/json
 Content-Length: 29
 
@@ -1306,7 +1306,7 @@ Content-Length: 414
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-06-11 16:48:13 +0900
+Last updated 2023-06-11 17:27:32 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### 이슈
[x] gradlew 배포 시 버전,폴더 문제 수정 

### 작업사항
* 배포시 필요한 폴더가 생성되도록 수정하였습니다.
* 배포시 gradlew 버전을 변경했습니다.

### 작업 이유
* 기존 배포시 -x를 사용 시 테스트가 실행되지 않아 폴더가 생성되지 않았는데 그럼으로 인해 문서화가 불가능해 문제가 발생헀습니다.
